### PR TITLE
CMake refactored + small changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,15 +1,41 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
-# project information
-project(semiprof)
-enable_language(CXX)
+if(NOT DEFINED PROJECT_NAME)
+  set(SEMIPROF_NOT_SUBPROJECT ON)
+endif()
 
-# turn on profiler
-add_definitions(-DSEMIPROF)
+project(semiprof VERSION 1.0 LANGUAGES CXX)
 
-# create the semiprof library
-add_library(semiprof src/profiler.cpp)
-target_include_directories(semiprof PUBLIC ${PROJECT_SOURCE_DIR}/include/semiprof)
+add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
+target_include_directories(semiprof PUBLIC 
+  $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/semiprof>
+  )
+target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
 
-# compile the examples
-add_subdirectory(examples)
+if(SEMIPROF_NOT_SUBPROJECT)
+  add_subdirectory(examples)
+endif()
+
+if(SEMIPROF_NOT_SUBPROJECT)
+  install(TARGETS semiprof
+          EXPORT semiprof_targets 
+          LIBRARY DESTINATION lib
+          INCLUDES DESTINATION include)
+
+  install(EXPORT semiprof_targets
+          FILE semiprofConfig.cmake
+          NAMESPACE semiprof::
+          DESTINATION lib/cmake/semiprof)
+
+  install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
+          DESTINATION include)
+
+  include(CMakePackageConfigHelpers)
+  write_basic_package_version_file(
+    "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+    VERSION ${semiprof_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
+  install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+          DESTINATION lib/cmake/semiprof)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,29 +16,27 @@ if(SEMIPROF_NOT_SUBPROJECT)
   add_subdirectory(examples)
 endif()
 
-if(SEMIPROF_NOT_SUBPROJECT)
-  include(CMakePackageConfigHelpers)
-  include(GNUInstallDirs)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
 
-  install(TARGETS semiprof
-          EXPORT semiprof_targets 
-          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(TARGETS semiprof
+        EXPORT semiprof_targets 
+        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-  install(EXPORT semiprof_targets
-          FILE semiprofConfig.cmake
-          NAMESPACE semiprof::
-          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
+install(EXPORT semiprof_targets
+        FILE semiprofConfig.cmake
+        NAMESPACE semiprof::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
 
-  install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
-          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
+        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-  write_basic_package_version_file(
-    "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
-    VERSION ${semiprof_VERSION}
-    COMPATIBILITY SameMajorVersion)
+write_basic_package_version_file(
+  "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+  VERSION ${semiprof_VERSION}
+  COMPATIBILITY SameMajorVersion)
 
-  install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
-          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
-endif()
+install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ if(SEMIPROF_NOT_SUBPROJECT)
   install(TARGETS semiprof
           EXPORT semiprof_targets 
           LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
           INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
   install(EXPORT semiprof_targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(semiprof VERSION 1.0 LANGUAGES CXX)
 if (NOT TARGET semiprof)
     add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
     target_include_directories(semiprof PUBLIC 
-      $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/semiprof>
+      $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include>
       )
     target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
 endif()
@@ -27,26 +27,26 @@ endif()
 if(SEMIPROF_WITH_INSTALL)
     include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
-    
+
     install(TARGETS semiprof
             EXPORT semiprof_targets 
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    
+
     install(EXPORT semiprof_targets
             FILE semiprofConfig.cmake
             NAMESPACE semiprof::
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
-    
+
     install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
             DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-    
+
     write_basic_package_version_file(
       "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
       VERSION ${semiprof_VERSION}
       COMPATIBILITY SameMajorVersion)
-    
+
     install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,15 @@ option(SEMIPROF_WITH_INSTALL "Enable installation." ${MASTER_PROJECT})
 
 project(semiprof VERSION 1.0 LANGUAGES CXX)
 
-add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
-target_include_directories(semiprof PUBLIC 
-  $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/semiprof>
-  )
-target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
+# Prevents target conflicts if project is nested multiple times.
+#
+if (NOT TARGET semiprof)
+    add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
+    target_include_directories(semiprof PUBLIC 
+      $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/semiprof>
+      )
+    target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
+endif()
 
 if(SEMIPROF_WITH_EXAMPLES)
     add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,12 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
+set(MASTER_PROJECT OFF)
 if(NOT DEFINED PROJECT_NAME)
-  set(SEMIPROF_NOT_SUBPROJECT ON)
+    set(MASTER_PROJECT ON)
 endif()
+
+option(SEMIPROF_WITH_EXAMPLES "Enable examples." ${MASTER_PROJECT})
+option(SEMIPROF_WITH_INSTALL "Enable installation." ${MASTER_PROJECT})
 
 project(semiprof VERSION 1.0 LANGUAGES CXX)
 
@@ -12,31 +16,34 @@ target_include_directories(semiprof PUBLIC
   )
 target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
 
-if(SEMIPROF_NOT_SUBPROJECT)
-  add_subdirectory(examples)
+if(SEMIPROF_WITH_EXAMPLES)
+    add_subdirectory(examples)
 endif()
 
-include(CMakePackageConfigHelpers)
-include(GNUInstallDirs)
+if(SEMIPROF_WITH_INSTALL)
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+    
+    install(TARGETS semiprof
+            EXPORT semiprof_targets 
+            LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+            INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    
+    install(EXPORT semiprof_targets
+            FILE semiprofConfig.cmake
+            NAMESPACE semiprof::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
+    
+    install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
+            DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+    
+    write_basic_package_version_file(
+      "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+      VERSION ${semiprof_VERSION}
+      COMPATIBILITY SameMajorVersion)
+    
+    install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
+endif()
 
-install(TARGETS semiprof
-        EXPORT semiprof_targets 
-        LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-        INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-
-install(EXPORT semiprof_targets
-        FILE semiprofConfig.cmake
-        NAMESPACE semiprof::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
-
-install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
-
-write_basic_package_version_file(
-  "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
-  VERSION ${semiprof_VERSION}
-  COMPATIBILITY SameMajorVersion)
-
-install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,23 +12,25 @@ project(semiprof VERSION 1.0 LANGUAGES CXX)
 
 # Prevents target conflicts if project is nested multiple times.
 #
+set(INSTALLED_TARGETS_LIST "")
 if (NOT TARGET semiprof)
     add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
     target_include_directories(semiprof PUBLIC 
       $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include>
      )
     target_compile_definitions(semiprof PUBLIC SEMIPROF) # Turn on profiler
+    set(INSTALLED_TARGETS_LIST "semiprof")
 endif()
 
 if(SEMIPROF_WITH_EXAMPLES)
     add_subdirectory(examples)
 endif()
 
-if(SEMIPROF_WITH_INSTALL)
+if(SEMIPROF_WITH_INSTALL AND INSTALLED_TARGETS_LIST)
     include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
 
-    install(TARGETS semiprof
+    install(TARGETS ${INSTALLED_TARGETS_LIST}
             EXPORT semiprof_targets 
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,9 +15,9 @@ project(semiprof VERSION 1.0 LANGUAGES CXX)
 if (NOT TARGET semiprof)
     add_library(semiprof STATIC "${semiprof_SOURCE_DIR}/src/profiler.cpp")
     target_include_directories(semiprof PUBLIC 
-      $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/semiprof>
+      $<BUILD_INTERFACE:${semiprof_SOURCE_DIR}/include/>
       )
-    target_compile_definitions(semiprof PRIVATE SEMIPROF) # Turn on profiler
+    target_compile_definitions(semiprof PUBLIC SEMIPROF) # Turn on profiler
 endif()
 
 if(SEMIPROF_WITH_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,13 +4,12 @@ cmake_minimum_required(VERSION 3.0)
 project(semiprof)
 enable_language(CXX)
 
-# set path for headers
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 # turn on profiler
 add_definitions(-DSEMIPROF)
 
 # create the semiprof library
 add_library(semiprof src/profiler.cpp)
+target_include_directories(semiprof PUBLIC ${PROJECT_SOURCE_DIR}/include/semiprof)
 
 # compile the examples
 add_subdirectory(examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,25 +17,27 @@ if(SEMIPROF_NOT_SUBPROJECT)
 endif()
 
 if(SEMIPROF_NOT_SUBPROJECT)
+  include(CMakePackageConfigHelpers)
+  include(GNUInstallDirs)
+
   install(TARGETS semiprof
           EXPORT semiprof_targets 
-          LIBRARY DESTINATION lib
-          INCLUDES DESTINATION include)
+          LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+          INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
   install(EXPORT semiprof_targets
           FILE semiprofConfig.cmake
           NAMESPACE semiprof::
-          DESTINATION lib/cmake/semiprof)
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
 
   install(FILES "${semiprof_SOURCE_DIR}/include/semiprof/semiprof.hpp"
-          DESTINATION include)
+          DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
-  include(CMakePackageConfigHelpers)
   write_basic_package_version_file(
     "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
     VERSION ${semiprof_VERSION}
     COMPATIBILITY SameMajorVersion)
 
   install(FILES "${semiprof_BINARY_DIR}/semiprofConfigVersion.cmake"
-          DESTINATION lib/cmake/semiprof)
+          DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/semiprof")
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,3 @@
 find_package(OpenMP REQUIRED)
-if (OpenMP_CXX_FOUND)
-    set(OPENMP_DEPS OpenMP::OpenMP_CXX)
-    add_executable(omp omp.cpp)
-    target_link_libraries(omp LINK_PUBLIC ${OPENMP_DEPS} semiprof)
-endif()
-
+add_executable(omp omp.cpp)
+target_link_libraries(omp PRIVATE OpenMP::OpenMP_CXX semiprof)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,7 @@
-FIND_PACKAGE(OpenMP REQUIRED)
-if(OPENMP_FOUND)
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
-
+find_package(OpenMP REQUIRED)
+if (OpenMP_CXX_FOUND)
+    set(OPENMP_DEPS OpenMP::OpenMP_CXX)
     add_executable(omp omp.cpp)
-    target_link_libraries(omp LINK_PUBLIC semiprof)
+    target_link_libraries(omp LINK_PUBLIC ${OPENMP_DEPS} semiprof)
 endif()
 

--- a/examples/omp.cpp
+++ b/examples/omp.cpp
@@ -3,7 +3,7 @@
 
 #include <omp.h>
 
-#include <semiprof/semiprof.hpp>
+#include <semiprof.hpp>
 
 int main() {
     std::cout << "-----------------------\n"

--- a/examples/omp.cpp
+++ b/examples/omp.cpp
@@ -3,7 +3,7 @@
 
 #include <omp.h>
 
-#include <semiprof.hpp>
+#include <semiprof/semiprof.hpp>
 
 int main() {
     std::cout << "-----------------------\n"

--- a/include/semiprof/semiprof.hpp
+++ b/include/semiprof/semiprof.hpp
@@ -47,11 +47,15 @@ std::ostream& operator<<(std::ostream&, const profile&);
     #define PL semiprof::profiler_leave
     #define PP() std::cout << semiprof::profiler_summary() << "\n"
 
+    // clears the profiler (counts and timings)
+    #define PC() semiprof::profiler_clear()
+
 #else
 
     #define PE(name)
     #define PL()
     #define PP()
+    #define PC()
 
 #endif
 

--- a/include/semiprof/semiprof.hpp
+++ b/include/semiprof/semiprof.hpp
@@ -45,11 +45,13 @@ std::ostream& operator<<(std::ostream&, const profile&);
 
     // leave a profling region
     #define PL semiprof::profiler_leave
+    #define PP() std::cout << semiprof::profiler_summary() << "\n"
 
 #else
 
     #define PE(name)
     #define PL()
+    #define PP()
 
 #endif
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -6,7 +6,7 @@
 #include <ostream>
 #include <thread>
 
-#include <semiprof/semiprof.hpp>
+#include <semiprof.hpp>
 
 namespace semiprof {
 

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -115,6 +115,7 @@ class profiler {
 public:
     profiler(unsigned max_threads=256);
 
+    void clear();
     void enter(region_id_type index);
     void enter(const char* name);
     void leave();
@@ -196,6 +197,10 @@ void profiler::enter(const char* name) {
 
 void profiler::leave() {
     recorders_[get_thread_info().thread_id].leave();
+}
+
+void profiler::clear() {
+    recorders_[get_thread_info().thread_id].clear();
 }
 
 region_id_type profiler::region_index(const char* name) {
@@ -357,6 +362,10 @@ void profiler_enter(region_id_type region_id) {
     profiler::get_global_profiler().enter(region_id);
 }
 
+void profiler_clear() {
+    profiler::get_global_profiler().clear();
+}
+
 // Print profiler statistics to an ostream
 std::ostream& operator<<(std::ostream& o, const profile& prof) {
     char buf[80];
@@ -379,6 +388,7 @@ profile profiler_summary() {
 
 void profiler_leave() {}
 void profiler_enter(region_id_type) {}
+void profiler_clear() {}
 profile profiler_summary();
 profile profiler_summary() {return profile();}
 region_id_type profiler_region_id(const char*) {return 0;}

--- a/src/profiler.cpp
+++ b/src/profiler.cpp
@@ -6,7 +6,7 @@
 #include <ostream>
 #include <thread>
 
-#include <semiprof.hpp>
+#include <semiprof/semiprof.hpp>
 
 namespace semiprof {
 


### PR DESCRIPTION
This PR brings the following changes:
- **CMake:** fully refactored, added installation option.
- **Macros defined:**  macros for entering/leaving profiling regions added.
- **Profiler reset:** previously, `profiler_clear()` function was not implemented, although recorder class implements this functionality. Now this function is also implemented. This is especially useful when multiple runs of the library to be profiled are performed and we want to exclude the "warm-up" run from the profiler data.